### PR TITLE
perf: do not remove duplicate on each call to useDictionary

### DIFF
--- a/src/useDictionary.js
+++ b/src/useDictionary.js
@@ -24,7 +24,8 @@ const useDictionary = () => {
   useEffect(() => {
     Promise.all(urls.map(fetchCSV))
       .then(wordLists => {
-        const words = wordLists.flat();
+        // Flatten the words lists, and remove duplicates.
+        const words = [...new Set(wordLists.flat())];
         setDict(words);
         setLoadingState(LOADED);
       })
@@ -33,7 +34,7 @@ const useDictionary = () => {
       });
   }, []);
 
-  return [loadingState, [...new Set(dict)]];
+  return [loadingState, dict];
 };
 
 export default useDictionary;


### PR DESCRIPTION
Current implementation of `useDictionnary` removes duplicates from `dict` on each call to the hook, instead of once and for all. Since it is currently used by `App`, this caused the duplicate removal to happen on every `App` render for example.