### PR TITLE
suggestion bar not appearing for small words fix

### DIFF
--- a/src/experiment/getSuggestions.js
+++ b/src/experiment/getSuggestions.js
@@ -38,10 +38,13 @@ const suggestionScore = (suggestionFScore, suggestion, inputWord) => {
 };
 
 function isCloseFromTargetWord(word, targetWord) {
-  return (
-    targetWord.startsWith(word.slice(0, -2)) ||
-    word.startsWith(targetWord.slice(0, -2))
-  );
+  if (targetWord.length > 2) {
+    return (
+      targetWord.startsWith(word.slice(0, -2)) ||
+      word.startsWith(targetWord.slice(0, -2))
+    );
+  }
+  return false;
 }
 
 function computeSuggestions(


### PR DESCRIPTION
isCloseFromTargetWord returns false if word length is too small

Closes #85.