### PR TITLE
change tuto last word's sks

### DIFF
--- a/src/experiment/components/Tutorial.js
+++ b/src/experiment/components/Tutorial.js
@@ -21,7 +21,7 @@ const tutorialSksDistribution = [
   { word: "with ", sks: 0 },
   { word: "a ", sks: 0 },
   { word: "zoom ", sks: 3 },
-  { word: "lens ", sks: 1 }
+  { word: "lens ", sks: 0 }
 ];
 
 const tutorialSentence = getTextFromSksDistribution(tutorialSksDistribution);


### PR DESCRIPTION
Prevents the correct suggestion to show up on the last word of the tutorial, to ensure participants will see the last step about the white space.